### PR TITLE
SPARQL Test Fixes for Concepts being in multiple ConceptSchemes.

### DIFF
--- a/tests/pmd/pmd4/concept-schemes/SELECT_ConceptMaxOneNotation.sparql
+++ b/tests/pmd/pmd4/concept-schemes/SELECT_ConceptMaxOneNotation.sparql
@@ -4,7 +4,7 @@ PREFIX qb:      <http://purl.org/linked-data/cube#>
 PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
 PREFIX ui:      <http://www.w3.org/ns/ui#>
 
-SELECT ?concept (COUNT(?n) AS ?count) 
+SELECT ?concept (COUNT(DISTINCT ?n) AS ?count) 
         WHERE {
         { 
             ?concept a skos:Concept .

--- a/tests/pmd/pmd4/concept-schemes/SELECT_ConceptsMaxOfOneSortPriority.sparql
+++ b/tests/pmd/pmd4/concept-schemes/SELECT_ConceptsMaxOfOneSortPriority.sparql
@@ -1,17 +1,17 @@
 # Concepts Max Of One Sort Priority
-
 PREFIX qb:      <http://purl.org/linked-data/cube#>
 PREFIX skos:    <http://www.w3.org/2004/02/skos/core#>
 PREFIX ui:      <http://www.w3.org/ns/ui#>
 
-SELECT ?concept  (COUNT(?sp) AS ?count) ?scheme
+SELECT  ?concept ?scheme (count(distinct ?sp) as ?count)
 WHERE {
    { 
-    ?concept a skos:Concept ;
-             ui:sortPriority ?sp .
-    ?concept skos:inScheme ?scheme .
+    ?concept ui:sortPriority ?sp ;
+  skos:inScheme ?scheme ;
+  a skos:Concept .
+
   }
 }
-GROUP BY ?concept ?scheme
+GROUP BY  ?concept ?scheme
 HAVING (?count > 1)
-ORDER BY ?scheme ?concept
+ORDER BY ?concept ?scheme


### PR DESCRIPTION
If a concept is in multiple `skos:ConceptScheme`s, don't double count sortPriorities and notations.

https://github.com/Swirrl/cogs-issues/issues/189
https://github.com/Swirrl/cogs-issues/issues/190

This is breaking the family trade reference metadata build pipeline, so it would be good to fix it. https://ci.floop.org.uk/job/GSS_data/job/Trade/job/ref_data/276/testReport/