### PR TITLE
Correcting SPARQL test with concepts in multiple schemes

### DIFF
--- a/tests/pmd/pmd4/concept-schemes/SELECT_ConceptExactlyOneLabel.sparql
+++ b/tests/pmd/pmd4/concept-schemes/SELECT_ConceptExactlyOneLabel.sparql
@@ -7,7 +7,7 @@ PREFIX rdfs:    <http://www.w3.org/2000/01/rdf-schema#>
 
 SELECT ?concept ?count {
     {
-        SELECT ?concept (COUNT(?lbl) AS ?count) 
+        SELECT ?concept (COUNT(DISTINCT ?lbl) AS ?count) 
         WHERE {
         { 
             ?concept a skos:Concept .


### PR DESCRIPTION
Correcting a SPARQL test which erroneously counts multiple labels where a concept is in multiple skos:ConceptSchemes.

https://ci.floop.org.uk/job/GSS_data/job/Trade/job/ONS-International-trade-in-services-by-subnational-areas-of-the-UK/60/testReport/(root)/pmd_pmd4_concept-schemes/Concept_Exactly_One_Label__or_prefLabel_/

for example, the [UK identifier doesn't have multiple `rdfs:labels`](https://staging.gss-data.org.uk/tools/sparql?query=DESCRIBE%20%3Chttp%3A%2F%2Fdata.europa.eu%2Fnuts%2Fcode%2FUK%3E), but it is in multiple concept schemes (which causes the error).

