### PR TITLE
Allowing obs status columns to be defined as subPropertyOf sdmxa:obsS…

### DIFF
--- a/tests/qb/qb-ics/ic-15-measure_dimension_consistent.sparql
+++ b/tests/qb/qb-ics/ic-15-measure_dimension_consistent.sparql
@@ -19,7 +19,7 @@ SELECT *
       # However, if an sdmxa:obsStatus is set, then it will explain why a value is not present.
       # Note that this means we're introducing a violation to the qb specification.
       FILTER NOT EXISTS { 
-        ?dsd qb:component/qb:componentProperty sdmxa:obsStatus.
+        ?dsd qb:component/qb:componentProperty/rdfs:subPropertyOf* sdmxa:obsStatus.
         
         ?obs sdmxa:obsStatus [].
       }


### PR DESCRIPTION
…tatus instead of just matching directly on sdmxa:obsStatus (approved by @canwaf).